### PR TITLE
fix(cluster/instances/logs): correct the component filter options

### DIFF
--- a/apps/main/[3]cluster/[1]instances/[-2]_clusterId/[3]logs/components/LogsTable/index.tsx
+++ b/apps/main/[3]cluster/[1]instances/[-2]_clusterId/[3]logs/components/LogsTable/index.tsx
@@ -106,7 +106,7 @@ function getColumns(t: TFunction<''>) {
         tikv: { text: 'TiKV' },
         pd: { text: 'PD' },
         tiflash: { text: 'TiFlash' },
-        cdc: { text: 'TiCDC' },
+        ticdc: { text: 'TiCDC' },
       },
     },
     {


### PR DESCRIPTION
- Replace `cdc` with `ticdc`